### PR TITLE
Communicate InternPool indices for fully resolved, `struct`, `union` and `enum` type decls to the Language Server and implement hover for them

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -14,7 +14,7 @@ const ErrorBundle = std.zig.ErrorBundle;
 const fatal = std.process.fatal;
 
 const Value = @import("Value.zig");
-const Type = @import("Type.zig");
+pub const Type = @import("Type.zig");
 const target_util = @import("target.zig");
 const Package = @import("Package.zig");
 const introspect = @import("introspect.zig");
@@ -34,9 +34,9 @@ const libunwind = @import("libs/libunwind.zig");
 const libcxx = @import("libs/libcxx.zig");
 const wasi_libc = @import("libs/wasi_libc.zig");
 const clangMain = @import("main.zig").clangMain;
-const Zcu = @import("Zcu.zig");
+pub const Zcu = @import("Zcu.zig");
 const Sema = @import("Sema.zig");
-const InternPool = @import("InternPool.zig");
+pub const InternPool = @import("InternPool.zig");
 const Cache = std.Build.Cache;
 const c_codegen = @import("codegen/c.zig");
 const libtsan = @import("libs/libtsan.zig");
@@ -5279,16 +5279,45 @@ fn processOneJob(tid: Zcu.PerThread.Id, comp: *Compilation, job: Job) JobError!v
                 try pt.zcu.ensureFuncBodyAnalysisQueued(ip.getNav(nav).status.fully_resolved.val);
             }
         },
-        .resolve_type_fully => |ty| {
+        .resolve_type_fully => |ty| rtf: {
             const tracy_trace = traceNamed(@src(), "resolve_type_fully");
             defer tracy_trace.end();
 
-            const pt: Zcu.PerThread = .activate(comp.zcu.?, tid);
+            const zcu = comp.zcu.?;
+
+            const pt: Zcu.PerThread = .activate(zcu, tid);
             defer pt.deactivate();
-            Type.fromInterned(ty).resolveFully(pt) catch |err| switch (err) {
+
+            const ttype = Type.fromInterned(ty);
+            ttype.resolveFully(pt) catch |err| switch (err) {
                 error.OutOfMemory, error.Canceled => |e| return e,
                 error.AnalysisFail => return,
             };
+
+            const lsp_doc_store = zcu.lsp_document_store orelse break :rtf;
+            if (switch (zcu.intern_pool.indexToKey(ty)) {
+                .enum_type,
+                .union_type,
+                .struct_type,
+                => true,
+                else => false,
+            }) {
+                const src_loc = ttype.srcLocOrNull(zcu) orelse break :rtf;
+                const resolved = src_loc.base_node_inst.resolveFull(&zcu.intern_pool) orelse break :rtf;
+                const file = zcu.fileByIndex(resolved.file);
+                const uri = file.uri_slice orelse break :rtf;
+                const zir = file.zir orelse break :rtf;
+                const src_node = move_to_Zir.getTypeDeclSrcNode(zir, resolved.inst) orelse break :rtf;
+                const lsp_doc = lsp_doc_store.getHandle(uri) orelse break :rtf;
+                lsp_doc.computed_data.lock.lockUncancelable(lsp_doc_store.io);
+                defer lsp_doc.computed_data.lock.unlock(lsp_doc_store.io);
+                lsp_doc.computed_data.zcu = comp.zcu;
+                try lsp_doc.computed_data.nodes.put(
+                    lsp_doc_store.allocator,
+                    src_node,
+                    .{ .ty = ty, .tid = tid },
+                );
+            }
         },
         .analyze_mod => |mod| {
             const tracy_trace = traceNamed(@src(), "analyze_mod");
@@ -5317,6 +5346,48 @@ fn processOneJob(tid: Zcu.PerThread.Id, comp: *Compilation, job: Job) JobError!v
         },
     }
 }
+
+// Flesh out and move to a proper location, eg extended-zccs..
+const move_to_Zir = struct {
+    pub fn getTypeDeclSrcNode(zir: Zir, type_decl: Zir.Inst.Index) ?std.zig.Ast.Node.Index {
+        const inst = zir.instructions.get(@intFromEnum(type_decl));
+        if (inst.tag != .extended) return null;
+        switch (inst.data.extended.opcode) {
+            .struct_decl => {
+                const extra = zir.extraData(Zir.Inst.StructDecl, inst.data.extended.operand).data;
+                return extra.src_node;
+            },
+            .union_decl => {
+                const extra = zir.extraData(Zir.Inst.UnionDecl, inst.data.extended.operand).data;
+                return extra.src_node;
+            },
+            .enum_decl => {
+                const extra = zir.extraData(Zir.Inst.EnumDecl, inst.data.extended.operand).data;
+                return extra.src_node;
+            },
+            .opaque_decl => {
+                const extra = zir.extraData(Zir.Inst.OpaqueDecl, inst.data.extended.operand).data;
+                return extra.src_node;
+            },
+            .reify_struct => {
+                const extra = zir.extraData(Zir.Inst.ReifyStruct, inst.data.extended.operand).data;
+                return extra.node;
+            },
+            .reify_union => {
+                const extra = zir.extraData(Zir.Inst.ReifyUnion, inst.data.extended.operand).data;
+                return extra.node;
+            },
+            .reify_enum => {
+                const extra = zir.extraData(Zir.Inst.ReifyEnum, inst.data.extended.operand).data;
+                return extra.node;
+            },
+            else => {
+                std.log.err("incorrect opcode: {t}", .{inst.data.extended.opcode});
+                return null;
+            },
+        }
+    }
+};
 
 fn createDepFile(comp: *Compilation, dep_file: []const u8, bin_file: Cache.Path) anyerror!void {
     const io = comp.io;

--- a/src/Lsp/src/DocumentStore.zig
+++ b/src/Lsp/src/DocumentStore.zig
@@ -17,7 +17,16 @@ const DocumentScope = @import("DocumentScope.zig");
 const DiagnosticsCollection = @import("DiagnosticsCollection.zig");
 const Server = @import("Server.zig");
 const compiler_main = if (!builtin.is_test) @import("root") else void;
-const Compilation = if (!builtin.is_test and @hasDecl(compiler_main, "Compilation")) compiler_main.Compilation else struct {
+pub const Compilation = if (!builtin.is_test and @hasDecl(compiler_main, "Compilation")) compiler_main.Compilation else struct {
+    pub const decoy = {};
+    pub const InternPool = struct {
+        pub const Index = void;
+    };
+    pub const Zcu = struct {
+        pub const PerThread = struct {
+            pub const Id = void;
+        };
+    };
     pub fn destroy(_: anytype) void {}
 };
 const CompilationState = if (!builtin.is_test and @hasDecl(compiler_main, "CompilationState")) compiler_main.CompilationState else struct {
@@ -327,6 +336,15 @@ pub const Handle = struct {
 
     mtime: std.Io.Timestamp = .{ .nanoseconds = 0 },
 
+    computed_data: struct {
+        lock: std.Io.RwLock = .init,
+        zcu: ?*Compilation.Zcu = null,
+        nodes: std.AutoHashMapUnmanaged(Ast.Node.Index, struct {
+            ty: Compilation.InternPool.Index,
+            tid: Compilation.Zcu.PerThread.Id,
+        }) = .empty,
+    } = .{},
+
     /// private field
     impl: struct {
         /// @bitCast from/to `Status`
@@ -459,6 +477,8 @@ pub const Handle = struct {
         }
 
         if (self.closest_build_file_uri) |cbfuri| allocator.free(cbfuri);
+
+        self.computed_data.nodes.deinit(allocator);
 
         self.* = undefined;
     }
@@ -715,7 +735,7 @@ pub const Handle = struct {
     }
 
     /// returns the previous value
-    fn setLspSynced(self: *Handle, lsp_synced: bool) bool {
+    pub fn setLspSynced(self: *Handle, lsp_synced: bool) bool {
         if (lsp_synced) {
             return self.impl.status.bitSet(@offsetOf(Handle.Status, "lsp_synced"), .release) == 1;
         } else {
@@ -1792,17 +1812,22 @@ fn createAndStoreDocument(
     };
     errdefer new_handle.deinit();
 
-    stat: {
-        const file_path = URI.toFsPath(self.allocator, uri) catch break :stat;
+    new_handle.mtime = stat: {
+        const now: std.Io.Timestamp = .now(self.io, .real);
+        const file_path = URI.toFsPath(self.allocator, uri) catch break :stat now;
         defer self.allocator.free(file_path);
         if (!std.fs.path.isAbsolute(file_path)) {
             log.err("stat: path is not absolute '{s}'", .{file_path});
-            break :stat;
+            break :stat now;
         }
-        const file = std.Io.Dir.openFileAbsolute(self.io, file_path, .{}) catch break :stat;
+        const file = std.Io.Dir.openFileAbsolute(self.io, file_path, .{}) catch break :stat now;
         defer file.close(self.io);
-        new_handle.mtime = .now(self.io, .real);
-    }
+        const stat = file.stat(self.io) catch |err| switch (err) {
+            error.Canceled => return error.Canceled,
+            else => break :stat now,
+        };
+        break :stat stat.mtime;
+    };
 
     if (supports_build_system and isBuildFile(uri) and !isInStd(uri)) {
         _ = try self.getOrLoadBuildFile(uri);
@@ -1818,7 +1843,8 @@ fn createAndStoreDocument(
         if (lsp_synced) {
             new_handle.impl.associated_build_file = gop.value_ptr.*.impl.associated_build_file;
             gop.value_ptr.*.impl.associated_build_file = .init;
-
+            new_handle.computed_data = gop.value_ptr.*.computed_data;
+            gop.value_ptr.*.computed_data = .{};
             new_handle.uri = gop.key_ptr.*;
             gop.value_ptr.*.deinit();
             gop.value_ptr.*.* = new_handle;

--- a/src/Lsp/src/Server.zig
+++ b/src/Lsp/src/Server.zig
@@ -1275,7 +1275,10 @@ fn saveDocumentHandler(server: *Server, arena: std.mem.Allocator, notification: 
 }
 
 fn closeDocumentHandler(server: *Server, _: std.mem.Allocator, notification: types.TextDocument.DidCloseParams) error{Canceled}!void {
-    server.document_store.closeLspSyncedDocument(notification.textDocument.uri);
+    // server.document_store.closeLspSyncedDocument(notification.textDocument.uri);
+
+    const handle = server.document_store.getHandle(notification.textDocument.uri) orelse return;
+    _ = handle.setLspSynced(false);
 
     if (server.client_capabilities.supports_publish_diagnostics) {
         server.diagnostics_collection.clearSingleDocumentDiagnostics(notification.textDocument.uri);

--- a/src/Lsp/src/analysis.zig
+++ b/src/Lsp/src/analysis.zig
@@ -5166,6 +5166,7 @@ pub fn getPositionContext(
                 break :new_state .{ .keyword = current_token };
             },
             .keyword_test => .{ .test_doctest_name = .{ .start = tok.loc.end, .end = tok.loc.end } },
+            .keyword_struct, .keyword_enum, .keyword_union => .{ .keyword = current_token },
             .container_doc_comment => .comment,
             .doc_comment => new_state: {
                 if (!curr_ctx.isErrSetDef()) break :new_state .comment; // Intent is to skip everything between the `error{...}` braces

--- a/src/Lsp/src/features/hover.zig
+++ b/src/Lsp/src/features/hover.zig
@@ -534,6 +534,79 @@ fn hoverDefinitionNumberLiteral(
     };
 }
 
+fn hoverKeyword(
+    ds: *DocumentStore,
+    arena: std.mem.Allocator,
+    handle: *DocumentStore.Handle,
+    token_index: Ast.TokenIndex,
+    markup_kind: types.MarkupKind,
+    offset_encoding: offsets.Encoding,
+) error{OutOfMemory}!?types.Hover {
+    if (@hasDecl(DocumentStore.Compilation, "decoy")) return null;
+    const tree = &handle.tree;
+
+    switch (tree.tokenTag(token_index)) {
+        else => return null,
+        .keyword_enum,
+        .keyword_union,
+        .keyword_struct,
+        => {},
+    }
+
+    const nodes = try ast.nodesOverlappingIndex(arena, tree, tree.tokenStart(token_index));
+    if (nodes.len == 0) return null;
+
+    handle.computed_data.lock.lockSharedUncancelable(ds.io);
+    defer handle.computed_data.lock.unlockShared(ds.io);
+
+    if (handle.computed_data.zcu == null) return null;
+
+    const args = handle.computed_data.nodes.get(nodes[0]) orelse return null;
+
+    const pt: DocumentStore.Compilation.Zcu.PerThread = .activate(handle.computed_data.zcu.?, args.tid);
+    defer pt.deactivate();
+
+    switch (pt.zcu.intern_pool.indexToKey(args.ty)) {
+        .enum_type,
+        .union_type,
+        .struct_type,
+        => {
+            var output: std.ArrayList(u8) = .empty;
+
+            if (markup_kind == .markdown) {
+                try output.print(arena, "```zig\n", .{});
+            }
+
+            const ty = DocumentStore.Compilation.Type.fromInterned(args.ty);
+
+            try output.print(arena,
+                \\size: {}
+                \\align({t})
+                \\fqn: {f}
+            , .{
+                ty.abiSize(pt.zcu),
+                ty.abiAlignment(pt.zcu),
+                ty.fmt(pt),
+            });
+
+            if (markup_kind == .markdown) {
+                try output.print(arena, "\n```\n", .{});
+            }
+
+            return .{
+                .contents = .{ .markup_content = .{
+                    .kind = markup_kind,
+                    .value = output.items,
+                } },
+                .range = offsets.locToRange(handle.tree.source, offsets.tokenToLoc(tree, token_index), offset_encoding),
+            };
+        },
+        else => {},
+    }
+
+    return null;
+}
+
 pub fn hover(
     ds: *DocumentStore,
     analyser: *Analyser,
@@ -552,6 +625,7 @@ pub fn hover(
         .label_access, .label_decl => |loc| try hoverDefinitionLabel(ds, analyser, arena, handle, source_index, loc, markup_kind, offset_encoding),
         .enum_literal => try hoverDefinitionEnumLiteral(ds, analyser, arena, handle, source_index, markup_kind, offset_encoding),
         .number_literal, .char_literal => try hoverDefinitionNumberLiteral(arena, handle, source_index, markup_kind, offset_encoding),
+        .keyword => |token_index| try hoverKeyword(ds, arena, handle, token_index, markup_kind, offset_encoding),
         else => null,
     };
 

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -1219,6 +1219,12 @@ pub const File = struct {
         file.uri_slice = uri_slice;
         return if (zcu.lsp_document_store) |doc_store| doc_store.getHandle(uri_slice) else null;
     }
+
+    pub fn getOrLoadLspDocHandle(file: *File, zcu: *const Zcu) (error{Canceled} || Allocator.Error)!?*LspDocumentStore.Handle {
+        const uri_slice = file.uri_slice orelse try file.pathToUriSlice(zcu) orelse return null;
+        file.uri_slice = uri_slice;
+        return if (zcu.lsp_document_store) |doc_store| doc_store.getOrLoadHandle(uri_slice) else null;
+    }
 };
 
 /// Represents the contents of a file loaded with `@embedFile`.

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -172,7 +172,7 @@ pub fn updateFile(
     };
     defer source_file.close(io);
 
-    const lsp_doc = file.getLspDocHandle(zcu) catch null;
+    const lsp_doc = try file.getOrLoadLspDocHandle(zcu);
 
     var stat = try source_file.stat(io);
 


### PR DESCRIPTION
# Data only available for referenced type decls

https://github.com/user-attachments/assets/e6e200fa-b687-448e-8d25-f0a27bbdc4a6

Progress towards
- #2 